### PR TITLE
limited / full access modules

### DIFF
--- a/neps/nep-0605-sharded-contracts.md
+++ b/neps/nep-0605-sharded-contracts.md
@@ -108,7 +108,7 @@ trait HostFunctions {
     fn call_sharded_contract(
         // The account id of the account to call
         account_id: AccountId,
-        sharded_contract_type: CallShardedContractReceiver,
+        sharded_contract_id: GlobalContractCodeIdentifier,
         // These two arguments are a simplification of the existing args
         // for the normal cross contract call.
         function: &str,
@@ -116,48 +116,29 @@ trait HostFunctions {
     );
 }
 
-/// When calling a sharded contract code using `call_sharded_contract`, this
-/// enum specifies which code to call.
-enum CallShardedContractReceiver {
-    /// When an immutable sharded contract code is being called, the following
-    /// information is needed.
-    Mutable {
-        /// AccountId of the account where the sharded contract code is
-        /// deployed.
-        account_id: AccountId,
-        /// In between a sender sending the message and the receiver executing
-        /// it, the contract code could have been upgraded.  The field can be
-        /// used to ensure that the receiver is using the desired version of
-        /// the code.
-        expected_code_hash: Option<CryptoHash>,
-    },
-    /// If an immutable sharded contract code is being called, just the code
-    /// hash is required and no versioning information is needed either.
-    Immutable { code_hash: CryptoHash },
+type ShardedContractInfo = GlobalContractCodeIdentifier;
+
+enum GlobalContractCodeIdentifier {
+    CodeHash(CryptoHash),
+    AccountId(AccountId),
 }
 
-enum ShardedContractInfo {
-    /// This is similar to immutable global contracts.  Once deployed, the
-    /// contract code cannot be updated.
-    Immutable { code_hash: CryptoHash },
-    /// This is similar to mutable global contracts.  The contract code can be
-    /// upgraded after being deployed.
-    Mutable {
-        /// Account id of the account where the sharded contract code is deployed.
-        account_id: AccountId,
-        /// Hash of the sharded contract code.
-        code_hash: CryptoHash,
-    },
-}
+
 
 // A smart contract function that can be used to initiate a FT transfer.
 fn send_tokens(amount: Balance, receiver: AccountId) {
+    // Avoid function call access keys from calling this method by requiring
+    // one yocto near as attached balance.
+    // This also stops limited sharded contracts from using this method.
+    near_sdk::assert_one_yocto();
+
     // Only the actual owner of the tokens should be allowed to call this
     // function.  To ensure this, the function checks if the caller of the
     // function is the same as the parent account that created it.
     let parent_account_id = HostFunctions::parent_account_id();
     let msg_sender = HostFunctions::predecessor_account_id();
     assert_eq!(parent_account_id, msg_sender);
+
 
     // Update the account balance
     let mut my_balance = HostFunctions::storage_read("balance");
@@ -191,8 +172,6 @@ fn send_tokens(amount: Balance, receiver: AccountId) {
         }
     }
 
-    // TODO: Should we emit an ft_transfer events here?  Or at the receiver?  Both?
-
     // This pseudocode assumes that `receive_tokens()` always succeeds.  In a
     // more complete version, if `receive_tokens()` fails, then this function
     // should undo the balance decrement above to ensure that tokens are not
@@ -211,43 +190,28 @@ fn receive_tokens(amount: Balance) {
     // the unwrap here allows ensures that this function is only called by a sharded contract code.
     let sender_sharded_contract_info = HostFunctions::predecessor_sharded_contract_info().unwrap();
 
-    match (my_sharded_contract_info, sender_sharded_contract_info) {
-        (
-            ShardedContractInfo::Immutable { code_hash: my_code_hash },
-            ShardedContractInfo::Immutable { code_hash: sender_code_hash },
-        ) => assert_eq!(my_code_hash, sender_code_hash),
-        (
-            ShardedContractInfo::Mutable { account_id: my_account_id, code_hash: my_code_hash },
-            ShardedContractInfo::Mutable { account_id: sender_account_id, code_hash: sender_code_hash },
-        ) => {
-            assert_eq!(my_account_id, sender_account_id);
-            // It is possible that in between the signer sending the message and
-            // the current account executing it, the sharded contract has been
-            // upgraded.  This means that the version of the contract that sent
-            // the message is different than the version that is executing it.
-            // This might potentially introduce some subtle malicious issues
-            // depending on the differences between the two versions. Hence, the
-            // receiver rejects any messages that are not sent from the same
-            // version as current.
-            assert_eq!(my_code_hash, sender_code_hash);
-        }
-        _ => panic!(),
-    }
+    assert_eq!(
+        my_sharded_contract_info,
+        sender_sharded_contract_info,
+        "Predecessor must be the same sharded contract"
+    );
 
     // Update the account balance
     let mut my_balance = HostFunctions::storage_read("balance");
     my_balance += amount;
     HostFunctions::storage_write("balance", my_balance);
+
+    // A complete implementation would also emit JSON events here.
 }
 ```
 
 With the above in place, following is the flow for how a sharded FT contract would be used.
 
-1. Each user that wants to use a sharded FT contract, will first start using it on their account using the `UseShardedContractAction` action.
-2. When `alice.near` wants to transfer tokens to `bob.near`, Alice calls the `send_tokens()` function on the sharded FT contract on her account using the `ShardedFunctionCallAction` action.
-3. `send_tokens()` ensures that caller is Alice as only the owner of the account should be allowed to initiate transfers.
-4. Next, the contract decrements the balance.
-5. Then, it sends a cross contract call to `bob.near` using the `ShardedFunctionCallAction` action.
+1. Each user that wants to use a sharded FT contract `ft.near`, will first deploy it on their account using the `SetShardedContractPermissionsAction` action, with `permissions: ShardedContractPermission::Limited { reserved_balance: 0 }`.
+2. When `alice.near` wants to transfer tokens to `bob.near`, Alice calls the `send_tokens()` function on the sharded FT contract on her account using the `ShardedFunctionCallAction` action, setting `receiver_sharded_contract_id: "ft.near"`.
+3. `send_tokens()` ensures that caller is `alice.near` and has 1 yocto NEAR attached, as full access to `alice.near` is required to initiate transfers.
+4. Next, the contract decrements the balance.  We will discuss access control issues to storage in the namespace section below.
+5. Then, it sends a shared cross contract call to `bob.near` using the `ShardedFunctionCallAction` action.
 6. `receive_tokens()` executes on `bob.near`.
 7. `receive_tokens()` ensures that the caller is an instance of the same sharded contract as itself otherwise it might be possible to mint tokens maliciously.
 8. `receive_tokens()` updates the balance stored locally.
@@ -260,9 +224,65 @@ Comparing this approach to the centralised approach, we note the following:
 
 ### Requirements
 
+#### Multiple contract codes
+
 One of the main high level requirements for this work is that users should not have to manage multiple sets of keys which would degrade the user experience.  In the FT example, it should be possible for a user to hold multiple FTs without having to manage multiple sets of keys.  This necessitates that multiple sharded contracts can be used by a single account.
 
 A follow on requirement of this is that if multiple contract codes are being used on a single account, then they need proper isolation to ensure that they cannot corrupt each other's state and it should be possible for the account owner to specify resource constraints on what the sharded contract codes can do.
+
+
+#### Access control to sharded contract functions
+
+We identified that sharded contracts may want to have 2 types of access control on functions.
+
+First are functions that can only be called by the account owner (e.g. `send_tokens()`).  This scenario is covered by the existing set of host functions and access keys.
+
+Second are functions that can only be called by another instance of the same contract.  Here the `ShardedFunctionCallAction` action provides information about the predecessor and the runtime can provide information about the current account.  And then as seen in `receive_tokens()`, the contract can then perform the appropriate checks.
+
+#### Access control for outgoing function calls
+
+For function calls on contracts, the `predecessor_id` is generally used to identify the caller.  Authorization code today assumes the caller has either a full access or function call access key on the predecessor, or the call originates from the code deployed on the account.
+
+To prevent limited access keys to move assets, such as FTs, an extra authorization step often checks that a function call has non-zero NEAR balance attached, which only a full access key or a contract call can do.
+
+Sharded contracts can be used in two ways:
+
+- Full access: Outgoing function calls look just like they come from the main account, hence they can move assets held on other contracts.
+- Limited: No "normal" function calls are allowed, only sharded function calls are possible.
+
+Any receiver of sharded function calls must check the `predecessor_id` + `predecessor_sharded_contract_info` combination for authorization.  This only affects code deployed as sharded contracts.
+
+Already deployed code on chain today need no update if they do not use sharded contracts.
+
+If a limited sharded contracts needs to call a non-sharded contract, it always has to go through a full access sharded contract.  The full access contract used to relay has to be prepared on the user account, too.  It should be a trustworthy contract with permissions checks in place that only allows specific outgoing calls.
+
+#### Access control for balance
+
+Full access sharded contracts can directly access the account balance without limits.
+Deploying a sharded contract with this permission level should be seen equivalent to giving that code a full access key to the account.
+
+Limited access sharded contracts have no direct access to balance. They must go through a full access sharded contract.
+
+Incoming balance on function calls (sharded and non-sharded) are always deposited on the account's single balance. Limited access contracts can check how much balance has been sent but it cannot 
+
+#### Storage limits
+
+An account must always hold a certain amount in NEAR balance to cover its storage cost.  Except, below 770 bytes, this limit is not applied to allow small zero-balance accounts. 
+
+Accounts with zero balance are important for the creation of sponsored accounts.  It prevents the incentive to claim and delete as many accounts as possible from a sponsor, since deleting a zero-balance account gives no financial gain.  Ideally, we can also add sharded contracts to an account while keeping its balance at 0.
+
+Sharded contracts require storage for their meta data, as well as for the namespaced state modified by WASM code.  Since sharded contracts do no have a separate balance, the storage usage should be added to the total account storage usage. The ZBA limit of 770 bytes is likely too small for many use cases.
+
+Another consideration is that the user should be able to set a limit on the state used by the sharded contract, given that state can only be deleted by the contract's code. Without limits, a sharded contract could lock up all NEAR tokens held on the account with no way for the user to get it back.
+
+Lastly, contract develops should also have a way to ensure their contract can access enough state.  If users can remove all currently unreserved balance, a contract would fail to increase its storage even by just a byte.
+
+To cover all these requirements, the proposal is as follows.
+
+- For limited sharded contracts, the user sets an explicit limit in `SetShardedContractPermissionsAction`.
+- Full access sharded contracts have no limits.  They are treated just like the main contract code.
+- Each sharded contract, limited or not, has its own ZBA limit that's added on top of the 770 bytes of the main account.
+
 
 ### Detailed specification
 
@@ -270,42 +290,66 @@ With the high level requirements and the pseudocode presented, we can discuss th
 
 We will reuse many of the mechanisms that are already built to deploy and distribute global contract code.  In particular, when a smart contract developer has built a sharded contract, they will use the `DeployGlobalContractAction` to deploy the code on their contract.  Note that this means that an account can use a global contract code in the sharded contract mode which may not have been the original intention of the smart contract developer.  We do not see any security concerns with allowing this.
 
-#### `UseShardedContractAction`
+#### `SetShardedContractPermissionsAction`
 
-Now that the smart contract developer has deployed their sharded contract on the network, users can start using it.  Assuming that users already have an account, they will use the `UseShardedContractAction` to use the sharded contract code on their account.  This action is similar to `UseGlobalContractAction` action but differs in the following ways.
+Now that the smart contract developer has deployed their sharded contract on the network, users can start using it.  Assuming that users already have an account, they will use the `SetShardedContractPermissionsAction` to use the sharded contract code on their account.
+
+This action, similar to the `UseGlobalContractAction`, takes a global contract code and enabled it for the account.  However, it does so for a sharded contract, rather than the main contract on the account.
 
 ```rust
-enum ShardedContractType {
-    /// The sharded contract cannot be upgraded
-    Immutable {
-        // code hash of the contract code.
-        code_hash: CryptoHash,
-    },
-    /// The sharded contract can be upgraded
-    Mutable {
-        // Account id of the account where the sharded contract code is deployed.
-        account_id: AccountId,
-    },
-}
-
-/// This action allows an account to start using a existing sharded contract
-/// code. This contract code can only be called by using the new
-/// `ShardedFunctionCallAction` action.
+/// This action allows an account to start using a existing sharded contract code.
 ///
 /// This action can be called multiple times on the same account to allow it to
 /// use multiple sharded contract codes simultaneously.
 ///
-/// This action is similar to creating a new account as it creates a sharded
-/// subordinate account.
-struct UseShardedContractAction {
-    /// information about which sharded contract to use
-    sharded_contract: ShardedContractType,
+/// Calling it with the same sharded contract id again allows updating
+/// permissions, including blocking all access by setting permissions to
+/// `ShardedContractPermission::None`.  This does not delete any state but it
+/// will make all incoming sharded function calls fail.
+struct SetShardedContractPermissionsAction {
+    // Account id of the account where the sharded contract code is deployed.
+    sharded_contract_id: GlobalContractCodeIdentifier,
+    permissions: ShardedContractPermission,
+}
+
+enum ShardedContractPermission {
+    /// The use is no longer using the sharded contract.
+    /// Functions equivalent to no using the sharded contract at all.
+    None,
+    /// Code inside the sharded contract has access to namespaced state up to the
+    /// storage balance limit and it can call other sharded contracts.
+    ///
+    /// All other actions are not allowed: Normal function calls, sending NEAR,
+    /// creating accounts, staking, yield-resume, changing access keys, ...
+    Limited {
+        /// This much balance is reserved for the limited module for storage and
+        /// cannot be transferred out of the account in any way.
+        /// Can be set to 0 to unreserve the balance.
+        /// Reducing it below actual storage usage will fail.
+        reserved_balance: Balance,
+    },
+    /// Code in this sharded contract has a namespaced state but otherwise behaves
+    /// exactly like the non-sharded contract on the same account.
+    ///
+    /// All actions are allowed, including NEAR transfers, deploying contract code,
+    /// and normal function calls.  The predecessor_id for function calls is the
+    /// account_id, without any way for the receiver to differentiate between a call
+    ///from the full access sharded contract vs a non-sharded cross-contract call.
+    FullAccess,
 }
 ```
 
 The action allows an account to use a global contract code that is already available on their shard in the sharded contract mode.
 
-This action is also similar to the `CreateAccountAction` action.  Further, this action can be called multiple times to use multiple different sharded contract codes on the same account.  To support this action, we propose that each time this action is issued, a new subordinate account is created.  Details of subordinate accounts are discussed below.
+Calling this action will insert or update the permission on the user's state trie for the specific sharded contract.
+
+```rust
+// new variant in TrieKey stores values of type `ShardedContractPermission`
+TrieKey::ShardedContractPermissions { 
+    identifier: GlobalContractCodeIdentifier,
+}
+```
+
 
 #### `ShardedFunctionCallAction`
 
@@ -316,147 +360,147 @@ Once an account is using a sharded contract code, the sharded contract code can 
 /// allows calling contract codes that are deployed using the
 /// `DeployContractAction` or the `UseGlobalContractAction` on an account.  This
 /// action allows calling contract codes that are deployed using the
-/// `UseShardedContractAction`.
+/// `SetShardedContractPermissionsAction`.
 struct ShardedFunctionCallAction {
     // An account can be using multiple sharded contract codes.  This identifies
     // which one should be called.
     receiver_sharded_contract: CallShardedContractReceiver,
-    // An account can be using multiple sharded contract codes.  This identifies
-    // which contract code on the predecessor is sending the action.  If this is
-    // `None`, then the caller is not using sharded contract code.
-    predecessor_sharded_contract: Option<ShardedContractType>,
     // additionally arguments are identical to `FunctionCallAction`.
 }
 ```
 
-#### `RemoveShardedContractAction`
+#### Storage namespace
 
-This action allows a user to stop using sharded contract code that it previously started using.  This is similar to the `DeleteAccountAction` as it will delete the subordinate account.  More details of what precisely will be deleted will be discussed in the subordinate accounts section below.
-
-```rust
-
-/// This action allows an account to stop using a sharded contract code.
-///
-/// This action is similar to deleting an account as it deletes a sharded
-/// subordinate account.
-struct RemoveShardedContractAction {
-    // Which sharded contract code to delete
-    sharded_contract: ShardedContractType,
-    // which account should get the remaining NEAR tokens
-    beneficiary_id: AccountId,
-}
-
-```
-
-### Subordinate accounts
-
-As briefly mentioned above, when there are multiple sharded contract codes being used on a single account, there are two high level requirements that need to be met:
-
-- There should be sufficient isolation between the state that the contract codes are using to ensure that there is no accidental or malicious corruption of state
-- Because the sharded contract code can contain bugs, the account should be allowed to set resource constraints on what the sharded contract code is allowed to do
-
-To meet these goals, we propose subordinate accounts.  Subordinate accounts are like normal accounts but have additional constraints.  Below is a chart for these constraints and then we explain them in more details.
-
-
-Trie column | Content | Duplicated perSubordinate |  
--- | -- | -- | --
-col::Account |   |   |  
-  | NEAR balance | No | No balance access by default
-  | NEAR locked for staking | No | No staking access by default
-  | NEAR locked for storage | No | No storage allowance above ZBA by default
-  | contract hash | No | Contract hash is stored in col::ShardedContract
-col::ContractCode | Full contract code | No | only global contract allowed
-col::ContractData | Smart contract state | Yes | isolate state
-col::AccessKey | Access keys | No | use same access keys as parent
-col::ShardedContract | Contract code and permissions | Yes | New column added for contract permissions
-
-#### Constraints
-
-In the MVP version of subordinate accounts, they will have the following constraints.
-
-Subordinate accounts cannot hold any NEAR tokens.  This will further imply that the maximum amount of state that they can use is limited to [770B](https://github.com/near/NEPs/blob/master/neps/nep-0448.md#specification).  The reason for this constraint is that if subordinate accounts can hold tokens, then they could send these tokens to other accounts in cross contract function calls which the parent account might want to restrict.  A bigger concern is that if the sharded contract was allowed to create arbitrarily large amounts of `ContractData`, then removing them might be difficult.  Today when an account is deleted, all of its `ContractData` is also deleted.  To ensure that deleting an account does not take too long, if an account has more than 10KiB of data, then it cannot be deleted.  To avoid these complications, in the MVP, we propose that subordinate accounts cannot hold tokens which ensures that they cannot accidentally / maliciously send tokens to other accounts and create arbitrarily large `ContractData`.
-
-Subordinate accounts are allowed to access only a restricted set of host functions.
-
-XXX: write down the exact list below.
-
-In particular, subordinate accounts are not allowed to create `FunctionCallAction` actions.  This is because, without further modifications to the protocol, the receiver of such actions would not be able to tell which contract code was calling it and it would allow a subordinate account to impersonate the parent account.
-
-#### Specification
-
-When `UseShardedContractAction` is called, a new subordinate account is created.  To support this, the `Account` struct is updated to the following:
-
-```rust
-pub enum Account {
-    V1(AccountV1),
-    V2(AccountV2),
-    V3(AccountV3),
-}
-
-enum ShardedContract {
-    Immutable(CryptoHash),
-    Mutable{
-        account_id: AccountId,
-        code_hash: CryptoHash,
-    },
-}
-
-struct SubordinateAccount {
-    /// This is guaranteed to not be higher than 770Bytes
-    storage_usage: StorageUsage,
-    contract: ShardedContract,
-}
-
-enum AccountV3 {
-    // Supports existing local and global types
-    Standard(AccountV2),
-    Subordinate(SubordinateAccount),
-}
-```
-
-Note that subordinate accounts do not have the ability to store tokens.  This means that they cannot send or receive tokens.  Further, the amount of state they can create is limited to 770 as per the zero balance accounts feature.
+Today when a local or global contract code call accesses the storage, the following function is used to create the trie key used:
 
 Next, both `storage_write()` and `storage_read()` host functions use the `create_storage_key()` function to access storage.  To provide sufficient isolation for the state that subordinate accounts are creating, the following changes are proposed.
+
+New variants are added to the `TrieKey` to help store the contract data from the subordinate accounts and `create_storage_key` is updated to create the appropriate trie key.  These changes ensure that each subordinate account has its own storage namespace that cannot be accessed or corrupted by others.
 
 ```rust
 enum TrieKey {
     ...
-    ShardedImmutableContractData {
+    // new variant in TrieKey stores user values just like `TrieKey::ContractData`
+    TrieKey::ShardedContractData { 
         account_id: AccountId,
-        code_hash: CryptoHash,
+        sharded_contract_id: GlobalContractCodeIdentifier,,
         key: Vec<u8>,
-    },
-    ShardedMutableContractData {
-        account_id: AccountId,
-        code_account_id: AccountId,
-        key: Vec<u8>,
-    },
+    }
 }
 
-pub fn create_storage_key(&self, key: &[u8], account_type: &AccountV3) -> TrieKey {
-    match account_type {
-        AccountV3::Standard(_) => {
-            TrieKey::ContractData { account_id: self.account_id.clone(), key: key.to_vec() }
-        }
-        AccountV3::Subordinate(subordinate_account) => match subordinate_account.contract {
-            ShardedContract::Immutable(code_hash) => TrieKey::ShardedImmutableContractData {
+fn create_storage_key(&self, key: &[u8], contract_type: ContractType) -> TrieKey {
+    match contract_type {
+        ContractType::MainContract => TrieKey::ContractData {
+            account_id: self.account_id.clone(),
+            key: key.to_vec(),
+        },
+        ContractType::Sharded(sharded_contract_id) => {
+            TrieKey::ShardedContractData {
                 account_id: self.account_id.clone(),
-                code_hash,
+                sharded_contract_id,
                 key: key.to_vec(),
-            },
-            ShardedContract::Mutable(code_account_id) => TrieKey::ShardedMutableContractData {
-                account_id: self.account_id.clone(),
-                code_account_id,
-                key: key.to_vec(),
-            },
+            }
         },
     }
 }
 ```
 
-New variants are added to the `TrieKey` to help store the contract data from the subordinate accounts and `create_storage_key` is updated to create the appropriate trie key.  These changes ensure that each subordinate account has its own storage namespace that cannot be accessed or corrupted by others.
+For serialization, we reuse the existing trie key representation of `GlobalContractCodeIdentifier`.
 
-Finally, as shown in the chart above, all subordinate accounts and the parent account share the same set of `AccessKey`s.
+```rust
+impl GlobalContractCodeIdentifier {
+    pub fn len(&self) -> usize {
+        1 + match self {
+            Self::CodeHash(hash) => hash.as_bytes().len(),
+            Self::AccountId(account_id) => {
+                // Corresponds to String repr in borsh spec
+                size_of::<u32>() + account_id.len()
+            }
+        }
+    }
+
+    pub fn append_into(&self, buf: &mut Vec<u8>) {
+        buf.extend(borsh::to_vec(self).unwrap());
+    }
+}
+```
+
+### Access Keys
+
+All subordinate accounts and the parent account share the same set of `AccessKey`s.
+
+If a sharded contract needs to limit access further, it can do so in WASM code.
+
+
+
+
+
+
+
+
+
+
+
+### Storage Limits Detailed Specification
+
+#### ZBA Limits for Sharded Contracts
+
+Each sharded contract, limited or not, has its own ZBA limit that's added on top of the 770 bytes of the main account.  The gas cost of `SetShardedContractPermissionsAction` is increased from its compute cost to pay for this limit in the same way the 770 bytes per account are paid for in the account creation.
+
+The limit per sharded contract is enough to store its permissions and a small number of contract state key-value pairs. Tentative proposal: 300 bytes per sharded contract.
+
+TODO: Exact math on limit
+
+Early estimate:
+
+- `TrieKey::ShardedContractData` requires 1 + 2 * (4 + 64) = 137 bytes  
+- `ShardedContractPermission` requires 1 + 16 = 17 bytes
+- Storing a `u128` on `balance` requires 16 bytes for the value, 7 bytes for the key, and 40 bytes for `storage_num_extra_bytes_record` = 63 bytes
+
+Hence, the required state of a sharded FT would be 217 bytes.
+
+Using the ft_transfer_call method on an account might require more state per outstanding transfer.  So the initial proposal is 300 bytes.
+
+Unlike the ZBA limit on accounts, even when a sharded contract goes over the ZBA limit, it will only need to maintain balance for the part over the ZBA limit.  (For accounts, once a contract is no longer in the ZBA limit, it has to hold Near for all bytes, since. This made migration easier when introducing ZBAs. Migration is not an issue here.)
+
+
+#### Storage Limits for Full Access Sharded Contracts
+
+State usage of a full access sharded contract is added directly to the main accounts limits.
+
+However, the ZBA limit per sharded contract (300 bytes) is free and not counted to the total limit.
+
+#### Storage Limits for Limited Sharded Contracts
+
+For limited sharded contracts, the user sets an explicit limit in `SetShardedContractPermissionsAction`.
+
+```rust
+SetShardedContractPermissionsAction {
+    sharded_contract_id: "alice.near".into(),
+    permissions: ShardedContractPermission::Limited {
+        reserved_balance: 1 * 10u128.pow(24),
+    },
+}
+```
+
+This limit, even if unused, is counted as locked storage on the account.
+
+```diff
+pub struct AccountV2 {
+    /// The total not locked tokens.
+    amount: Balance,
+    /// The amount locked due to staking.
+    locked: Balance,
+    /// Storage used by the given account, includes account id, this struct, access keys and other data.
++    ///
++    /// This now also includes the sum of storage limits of all sharded contracts
+    storage_usage: StorageUsage,
+    /// Type of contract deployed to this account, if any.
+    contract: AccountContract,
+}
+```
+
+Going over the limit will abort the sharded function call.  Users can reduce the limit any time but they can not go lower than the actual usage.
 
 ### Upgrading a sharded contract
 
@@ -476,7 +520,33 @@ This means that in the worst case, the owner of the contract has to include, in 
 - let's say that the contract has gone through version iterations `v0`, `v1`, ... `vN`.
 - then the `vN`th version of the contract code has to contain logic for the user upgrade their state to `vN` from `v0`, from `v1`, ... all the way to `v[N-1]`.
 
-We could decide that this is not really a problem if we assume that sharded contracts will not be upgraded very often and that providing all the upgrade paths will not be prohibitively expensive.
+We decided that this is acceptable, assuming that sharded contracts will not be upgraded very often and that providing all the upgrade paths will not be prohibitively expensive.
+
+To avoid version conflicts of in-flight function calls, smart contract developers have to implement a solution that works for them.  One suggestions is to use a new method name if it has a breaking change. (e.g. `send_tokens_v0` and `send_tokens_v1`). Where this is not possible, for example in standardised function names, the version can be a parameter of the function `send_tokens` that allows using `send_tokens_v0` and `send_tokens_v1` internally.
+
+```rust
+struct MethodVersion {
+    /// revision of the contract standard
+    standard: u32,
+    /// revision of the specific implementation
+    contract: u32,
+}
+
+pub fn send_tokens(amount: Balance, receiver: AccountId, version: MethodVersion) {
+    assert_eq!(version.standard, 0, "only standard v0 supported");
+    match version.contract {
+        0 => send_tokens_v0(amount, receiver),
+        1 => send_tokens_v1(amount, receiver),
+        other => panic!("Contract has not been updated for method version {other}"),
+    }
+}
+
+```
+
+### Deleting an Account with Sharded Contracts
+
+TODO: What happens when deleting an account with state in sharded contracts?
+
 
 ## Reference Implementation
 
@@ -487,6 +557,9 @@ TODO
 TODO
 
 ## Alternatives
+
+- Instead of explicit limited access / full-access permissions, we could say the sharded contract `ft.near` on `ft.near` implicitly has full access, while `ft.near` on any other account has only limited access.  This would mean anytime full access is required, we have to go through the central `ft.near@ft.near` account.
+- Instead of a ZBA limit per sharded contract, we could add a general way to burn tokens or gas for non-refundable storage on an account.  This would be its own NEP and limit what sharded contracts can do until that other NEP is also designed, approved and implemented.
 
 
 ## Future possibilities
@@ -516,6 +589,7 @@ None
 ## Unresolved Issues (Optional)
 
 - it is not possible for an account to remove the storage that a sharded contract created without the help of the sharded contract itself.
+- upgrading contracts is left to sharded contract developers to resolve
 
 
 ## Changelog

--- a/neps/nep-0605-sharded-contracts.md
+++ b/neps/nep-0605-sharded-contracts.md
@@ -263,7 +263,7 @@ We identified that sharded contracts may want to have 2 types of access control 
 
 First are functions that can only be called by the account owner (e.g. `send_tokens()`).  This scenario is covered by the existing set of host functions and access keys.
 
-Second are functions that can only be called by another instance of the same contract.  Here the runtime can provide information about the current context, as well as predecessor context.  And then, as seen in `receive_tokens()`, the contract can then perform the appropriate checks.
+Second are functions that can only be called by another instance of the same contract.  Here the runtime can provide information about the current context, as well as predecessor context.  And then, as seen in `receive_tokens()`, the contract can perform the appropriate checks.
 
 
 #### Access control for outgoing function calls

--- a/neps/nep-0605-sharded-contracts.md
+++ b/neps/nep-0605-sharded-contracts.md
@@ -7,7 +7,7 @@ DiscussionsTo: https://github.com/nearprotocol/neps/pull/0000
 Type: Protocol
 Version: 0.0.0
 Created: 2025-04-07
-LastUpdated: 2025-04-14
+LastUpdated: 2025-05-28
 ---
 
 ## Summary
@@ -47,13 +47,15 @@ The minimum latency of doing a single transaction is 2 blocks.  In the first blo
 Since all the account balances are stored in a single contract, this one contract has to be invoked in order to make any transfers.  Therefore, the maximum TPS of this contract is the maximum TPS of the shard it is deployed on.  The only way to increase this capacity would be to increase the capacity of the shard.  Adding more shards does not help.
 
 
-## Specification
+## High-level explanation
 
 In the centralised FT contract above, all the state is stored in a single centralised location.  The opposite extreme of this approach would be to store all the state in as distributed a manner as possible i.e. the account balances of each user is stored locally on their accounts instead.  This distributes it across shards and allows for horizontal scaling.
 
 Of course, we cannot just put the state in normal user storage without a way to mitigate them manipulating their FT balance.  We need a way to ensure only the real FT contract code can modify this state.
 
-Below, we explain how this can be implemented.
+To enable this isolation, we introduce a new action `SwitchContextAction`.  Within a receipt, all actions that follow a context switch are executed in a different context that has a separate storage namespace.
+
+Contexts can also have different permissions than the main account.  We introduce another new action called `SetContextPermissionsAction` to manage those permissions.
 
 ### Pseudocode for a sharded FT contract
 
@@ -79,51 +81,75 @@ trait HostFunctions {
     // function used to write contract state to the trie.
     fn storage_write(key: &str, amount: Balance);
 
-    // A new host function that returns information about the sharded contract
-    // code that is being used by the current account.
-    //
-    // If the contract code was called using a `FunctionCallAction`, then this
-    // function panics.  If it was called using a new
-    // `ShardedFunctionCallAction` then returns information about which sharded
-    // contract code that is being used by the current account.
-    fn current_sharded_contract_info() -> ShardedContractInfo;
+    // A new host function that returns information about the context in which
+    // the contract is running.
+    fn current_context() -> ContractContext;
 
     // A new host function that returns information about the sharded contract
     // code that is being used by the predecessor (i.e. the message sender)
     // account.
-    //
-    // If the predecessor (i.e. the message sender) called the current account
-    // using the new `ShardedFunctionCallAction` information about what type of
-    // sharded contract code the predecessor account is using.
-    //
-    // Returns: `None` if the sender is not using a sharded contract code.
-    fn predecessor_sharded_contract_info() -> Option<ShardedContractInfo>;
+    fn predecessor_context() -> ContractContext;
 
-    // A new host function that allows the current account to call another
-    // account using the new `ShardedFunctionCallAction` action instead of the
-    // `FunctionCallAction` action.
-    //
-    // This function will panic if the current account was not also called via
-    // `ShardedFunctionCallAction`.
-    fn call_sharded_contract(
-        // The account id of the account to call
-        account_id: AccountId,
-        sharded_contract_id: GlobalContractCodeIdentifier,
-        // These two arguments are a simplification of the existing args
-        // for the normal cross contract call.
-        function: &str,
-        args: Balance,
+    // A new host function that allows outgoing actions to execute in a sharded
+    // context on the receiver.
+    fn promise_batch_action_switch_context(
+        context: ContractContext,
+    );
+
+    // A new host function to enable / disable contexts or generally manage the
+    // permissions of a context.
+    fn promise_batch_action_set_context_permissions(
+        permissions: ContextPermissions,
     );
 }
 
-type ShardedContractInfo = GlobalContractCodeIdentifier;
+/// New enum to define the account context.
+#[non_exhaustive]
+enum ContractContext {
+    /// The root context is the default context, used when running in the main
+    /// namespace of an account.
+    Root,
+    /// Running under a sharded contract context, defined by a globally deployed code.
+    Sharded {
+        code_id: GlobalContractCodeIdentifier,
+    },
+}
 
+/// Existing enum used for global contract deployments
 enum GlobalContractCodeIdentifier {
     CodeHash(CryptoHash),
     AccountId(AccountId),
 }
 
-
+/// New enum to set permission level for a used sharded contract.
+#[non_exhaustive]
+enum ContextPermissions {
+    /// Code in this sharded contract has a namespaced state but otherwise behaves
+    /// exactly like the non-sharded contract on the same account.
+    ///
+    /// All actions are allowed, including NEAR transfers, deploying contract code,
+    /// and normal function calls.  The predecessor_id for function calls is the
+    /// account_id, without any way for the receiver to differentiate between a call
+    /// from the full access sharded contract vs a non-sharded cross-contract call.
+    FullAccess,
+    /// Code inside the sharded contract has access to namespaced state up to the
+    /// storage balance limit and it can call other sharded contracts.
+    ///
+    /// All other actions are not allowed: Normal function calls, sending NEAR,
+    /// creating accounts, staking, yield-resume, changing access keys, ...
+    Limited {
+        /// This much balance is reserved for the limited module for storage and
+        /// cannot be transferred out of the account in any way.
+        /// Can be set to 0 to unreserve the balance.
+        /// Reducing it below actual storage usage will fail.
+        reserved_balance: Balance,
+    },
+    /// The user has blocked all usage of the context.
+    ///
+    /// The state inside the context might still be stored.
+    /// Set a different permission to unblock again.
+    Blocked,
+}
 
 // A smart contract function that can be used to initiate a FT transfer.
 fn send_tokens(amount: Balance, receiver: AccountId) {
@@ -147,28 +173,13 @@ fn send_tokens(amount: Balance, receiver: AccountId) {
     HostFunctions::storage_write("balance", my_balance);
 
     // Call the receiver's account to receive the tokens.
-    let my_sharded_contract_info = HostFunctions::current_sharded_contract_info();
-    match my_sharded_contract_info {
-        ShardedContractInfo::Immutable { code_hash } => HostFunctions::call_sharded_contract(
-            receiver,
-            CallShardedContractReceiver::Immutable { code_hash },
-            "receive_tokens",
-            amount,
-        ),
-
-        ShardedContractInfo::Mutable { account_id, code_hash } => {
-            HostFunctions::call_sharded_contract(
-                receiver,
-                CallShardedContractReceiver::Mutable {
-                    account_id,
-                    // Ensure that the receiver is using the same version of
-                    // the contract code as the sender to ensure that there
-                    // are no subtle bugs introduced between upgrades.
-                    expected_code_hash: Some(code_hash),
-                },
-                "receive_tokens",
-                amount,
-            )
+    let sharded_context = HostFunctions::current_context();
+    match sharded_context {
+        ContractContext::Root => panic!("sharded contract should not run in root"),
+        ContractContext::Sharded { .. } => {
+            near_sdk::Promise::new(receiver)
+                .switch_context(sharded_context)
+                .function_call("receive_tokens", amount, 0, 5 * TGAS);
         }
     }
 
@@ -186,13 +197,13 @@ fn receive_tokens(amount: Balance) {
     //
     // To implement this check, the receiver has to make sure that the caller of
     // the function is an instance of the same sharded contract code.
-    let my_sharded_contract_info = HostFunctions::current_sharded_contract_info();
+    let my_context = HostFunctions::current_context();
     // the unwrap here allows ensures that this function is only called by a sharded contract code.
-    let sender_sharded_contract_info = HostFunctions::predecessor_sharded_contract_info().unwrap();
+    let sender_context = HostFunctions::predecessor_context().unwrap();
 
     assert_eq!(
-        my_sharded_contract_info,
-        sender_sharded_contract_info,
+        my_context,
+        sender_context,
         "Predecessor must be the same sharded contract"
     );
 
@@ -207,14 +218,25 @@ fn receive_tokens(amount: Balance) {
 
 With the above in place, following is the flow for how a sharded FT contract would be used.
 
-1. Each user that wants to use a sharded FT contract `ft.near`, will first deploy it on their account using the `SetShardedContractPermissionsAction` action, with `permissions: ShardedContractPermission::Limited { reserved_balance: 0 }`.
-2. When `alice.near` wants to transfer tokens to `bob.near`, Alice calls the `send_tokens()` function on the sharded FT contract on her account using the `ShardedFunctionCallAction` action, setting `receiver_sharded_contract_id: "ft.near"`.
-3. `send_tokens()` ensures that caller is `alice.near` and has 1 yocto NEAR attached, as full access to `alice.near` is required to initiate transfers.
-4. Next, the contract decrements the balance.  We will discuss access control issues to storage in the namespace section below.
-5. Then, it sends a shared cross contract call to `bob.near` using the `ShardedFunctionCallAction` action.
-6. `receive_tokens()` executes on `bob.near`.
-7. `receive_tokens()` ensures that the caller is an instance of the same sharded contract as itself otherwise it might be possible to mint tokens maliciously.
-8. `receive_tokens()` updates the balance stored locally.
+1. The owner of `ft.near` uses `DeployGlobalContractAction` to deploy the code under the `ft.near` name.
+2. Before `alice.near` can use the sharded FT contract `ft.near`, she has to enable it on her account.
+    - (`receiver_id="alice.near"`)
+    - `SwitchContextAction(Sharded("ft.near"))`
+    - `UseGlobalContractAction("ft.near")`
+    - `SetContextPermissionsAction(Limited { reserved_balance: 0 })`
+3. When `alice.near` wants to transfer tokens to `bob.near`, Alice calls the `send_tokens()` function on the sharded FT contract on her account using
+    - (`receiver_id="alice.near"`)
+    - `SwitchContextAction(Sharded("ft.near"))`
+    - `FunctionCallAction("send_tokens", balance=1, ...)`
+4. `send_tokens()` ensures that caller is `alice.near` and has 1 yocto NEAR attached, as full access to `alice.near` is required to initiate transfers.
+5. Next, the contract decrements the balance.  We will discuss access control issues to storage in the namespace section below.
+6. Then, it sends a sharded cross contract call from `alice.near` to `bob.near`
+    - (`receiver_id="bob.near"`)
+    - `SwitchContextAction(Sharded("ft.near"))`
+    - `FunctionCallAction("receive_tokens", ...)`
+7. `receive_tokens()` executes on `bob.near` in the `GlobalContractCodeIdentifier::AccountId("ft.near")` context.
+8. `receive_tokens()` ensures that the caller is an instance of the same sharded contract as itself otherwise it might be possible to mint tokens maliciously.
+9. `receive_tokens()` updates the balance stored locally.
 
 Comparing this approach to the centralised approach, we note the following:
 
@@ -222,13 +244,17 @@ Comparing this approach to the centralised approach, we note the following:
 - Just like the centralised case, the minimum latency is 2 blocks.  Even if both the sender and the receiver accounts live on the same shard, a following cross contract receipt always executes the earliest in the next block.
 - In the centralised situation, all function calls took place on a single shard, assuming a uniform distribution of accounts across the network, the 2 function calls will be uniformly distributed across all the shards of the network.  This implies that the maximum TPS of this application scenario will be the sum of the TPS of all the shards on the network.
 
+Next, we discuss the requirements on context isolation for sharded contracts to work as intended.
+
 ### Requirements
 
-#### Multiple contract codes
+#### Multiple contract modules per account
 
-One of the main high level requirements for this work is that users should not have to manage multiple sets of keys which would degrade the user experience.  In the FT example, it should be possible for a user to hold multiple FTs without having to manage multiple sets of keys.  This necessitates that multiple sharded contracts can be used by a single account.
+One of the main high level requirements for this work is that users should not have to manage multiple sets of keys which would degrade the user experience.  In the FT example, it should be possible for a user to hold multiple FTs without having to manage multiple sets of keys.  This necessitates that multiple sharded contracts can be used by a single account.  Using a context switching action allows to select a different contract code within the same account.
 
-A follow on requirement of this is that if multiple contract codes are being used on a single account, then they need proper isolation to ensure that they cannot corrupt each other's state and it should be possible for the account owner to specify resource constraints on what the sharded contract codes can do.
+A follow on requirement of this is that contexts must have proper isolation to ensure that they cannot corrupt each other's state.  Thus, each context has its own namespaced storage, which cannot be written from outside the context.  Even deleting the namespaced storage is only allowed from code inside the same context.
+
+The last piece for isolation of a sharded contract is who can deploy code inside the context.  We define that inside a sharded context identified by `ft.near`, only code globally deployed by `ft.near` can be used.
 
 
 #### Access control on incoming calls
@@ -237,15 +263,24 @@ We identified that sharded contracts may want to have 2 types of access control 
 
 First are functions that can only be called by the account owner (e.g. `send_tokens()`).  This scenario is covered by the existing set of host functions and access keys.
 
-Second are functions that can only be called by another instance of the same contract.  Here the `ShardedFunctionCallAction` action provides information about the predecessor and the runtime can provide information about the current account.  And then as seen in `receive_tokens()`, the contract can then perform the appropriate checks.
+Second are functions that can only be called by another instance of the same contract.  Here the runtime can provide information about the current context, as well as predecessor context.  And then, as seen in `receive_tokens()`, the contract can then perform the appropriate checks.
+
 
 #### Access control for outgoing function calls
 
-For function calls on contracts, the `predecessor_id` is generally used to identify the caller.  Authorization code today assumes the caller has either a full access or function call access key on the predecessor, or the call originates from the code deployed on the account.
+For cross contract calls, the `predecessor_id` authenticates the caller and is used for authorization in the receiver's code.
 
-To prevent limited access keys to move assets, such as FTs, an extra authorization step often checks that a function call has non-zero NEAR balance attached, which only a full access key or a contract call can do.
+Calls from a sharded contract will use the same `predecessor_id`.  But not all sharded contracts should have the ability to make cross contract calls in the account owner's name.
 
-The design of sharded contracts has to enable receivers to know whether they were called by a sharded contract on the predecessor, or by the owner of that account. This is especially tricky with existing code that is unaware of the existence of sharded contracts, hence they only look at the predecessor_id.
+We solve this with a permission system that can use a sharded contract but give it limited access.  Sharded contracts that need it can also be deployed with full access, it's the user's choice.
+
+
+#### Requirements on balance
+
+We did not find conclusive requirements on whether a context within an account needs an isolated balance or not.  The only requirement is that a limited context can not access the main balance of the account.
+
+As described in specification below, we decided to give no balance access at all to limited contexts.
+
 
 #### Storage limits
 
@@ -253,105 +288,64 @@ An account must always hold a certain amount in NEAR balance to cover its storag
 
 Accounts with zero balance are important for the creation of sponsored accounts.  It prevents the incentive to claim and delete as many accounts as possible from a sponsor, since deleting a zero-balance account gives no financial gain.  Ideally, we can also add sharded contracts to an account while keeping its balance at 0.
 
-Sharded contracts require storage for their meta data, as well as for the namespaced state modified by WASM code.  Since sharded contracts do no have a separate balance, the storage usage should be added to the total account storage usage. The ZBA limit of 770 bytes is likely too small for many use cases.
+Sharded contracts require storage for their context meta data, as well as for the namespaced state modified by WASM code.  Since sharded contracts do no have a separate balance, the storage usage should be added to the total account storage usage. The ZBA limit of 770 bytes is likely too small for many use cases.
 
-Another consideration is that the user should be able to set a limit on the state used by the sharded contract, given that state can only be deleted by the contract's code. Without limits, a sharded contract could lock up all NEAR tokens held on the account with no way for the user to get it back.
+Another consideration is that the user should be able to set a limit on the state used by the sharded contract, given that state can only be deleted by the contract's code.  Without limits, a sharded contract could lock up all NEAR tokens held on the account with no way for the user to get it back.
 
-Lastly, contract develops should also have a way to ensure their contract can access enough state.  If users can remove all currently unreserved balance, a contract would fail to increase its storage even by just a byte.
+Lastly, there should be a way to reserve storage space for a context.  Otherwise, users may accidentally move too many tokens out of their account, which could make deployed sharded contracts fail to allocate extra bytes they need.
+
+To satisfy all these needs, we decided to set the storage limit per context when setting the permissions.
 
 
-### Detailed specification
+## Specification
 
 With the high level requirements and the pseudocode presented, we can discuss the specification of the new primitives been proposed.
 
 We will reuse many of the mechanisms that are already built to deploy and distribute global contract code.  In particular, when a smart contract developer has built a sharded contract, they will use the `DeployGlobalContractAction` to deploy the code on their contract.  Note that this means that an account can use a global contract code in the sharded contract mode which may not have been the original intention of the smart contract developer.  We do not see any security concerns with allowing this.
 
-#### `SetShardedContractPermissionsAction`
+To use a globally deployed code in sharded-contract mode, users need to switch to the `ContractContext::Sharded` context and execute `UseGlobalContractAction` in the same receipt.
 
-Now that the smart contract developer has deployed their sharded contract on the network, users can start using it.  Assuming that users already have an account, they will use the `SetShardedContractPermissionsAction` to use the sharded contract code on their account.
 
-This action, similar to the `UseGlobalContractAction`, takes a global contract code and enabled it for the account.  However, it does so for a sharded contract, rather than the main contract on the account.
+#### Contract context switching
+
+Switching contract context is done with `SwitchContextAction`.  All actions within the same receipt but before the next `SwitchContextAction` will execute in the set context.
 
 ```rust
-/// This action allows an account to start using a existing sharded contract code.
-///
-/// This action can be called multiple times on the same account to allow it to
-/// use multiple sharded contract codes simultaneously.
-///
-/// Calling it with the same sharded contract id again allows updating
-/// permissions, including blocking all access by setting permissions to
-/// `ShardedContractPermission::None`.  This does not delete any state but it
-/// will make all incoming sharded function calls fail.
-struct SetShardedContractPermissionsAction {
-    // Account id of the account where the sharded contract code is deployed.
-    sharded_contract_id: GlobalContractCodeIdentifier,
-    permissions: ShardedContractPermission,
+struct SwitchContextAction {
+    caller: ContractContext,
+    target: ContractContext,
 }
+```
 
-enum ShardedContractPermission {
-    /// The use is no longer using the sharded contract.
-    /// Functions equivalent to no using the sharded contract at all.
-    None,
-    /// Code inside the sharded contract has access to namespaced state up to the
-    /// storage balance limit and it can call other sharded contracts.
-    ///
-    /// All other actions are not allowed: Normal function calls, sending NEAR,
-    /// creating accounts, staking, yield-resume, changing access keys, ...
-    Limited {
-        /// This much balance is reserved for the limited module for storage and
-        /// cannot be transferred out of the account in any way.
-        /// Can be set to 0 to unreserve the balance.
-        /// Reducing it below actual storage usage will fail.
-        reserved_balance: Balance,
+To enable sharded contracts, we introduce `ContractContext::Sharded`, which can select a global contract by account id or code hash as the context identifier.  All contracts deployed outside a context implicitly use the `ContractContext::Root` context.
+
+```rust
+#[non_exhaustive]
+enum ContractContext {
+    Root,
+    Sharded {
+        code_id: GlobalContractCodeIdentifier,
     },
-    /// Code in this sharded contract has a namespaced state but otherwise behaves
-    /// exactly like the non-sharded contract on the same account.
-    ///
-    /// All actions are allowed, including NEAR transfers, deploying contract code,
-    /// and normal function calls.  The predecessor_id for function calls is the
-    /// account_id, without any way for the receiver to differentiate between a call
-    ///from the full access sharded contract vs a non-sharded cross-contract call.
-    FullAccess,
 }
 ```
 
-The action allows an account to use a global contract code that is already available on their shard in the sharded contract mode.
+The called contract can use the `current_context()` host function to read the own contract context (`target`) and the `predecessor_context()` host function to read the calling contract's context (`caller`). 
 
-Calling this action will insert or update the permission on the user's state trie for the specific sharded contract.
+The rules for using `SwitchContextAction` are:
 
-```rust
-// new variant in TrieKey stores values of type `ShardedContractPermission`
-TrieKey::ShardedContractPermissions { 
-    identifier: GlobalContractCodeIdentifier,
-}
-```
+- Receipts created from a transaction must always set `caller = ContractContext::Root`.
+- Receipts created from a sharded contract must always set `caller = ContractContext::Sharded` with their respective code id.
 
 
-#### `ShardedFunctionCallAction`
+The rules inside a sharded context are:
 
-Once an account is using a sharded contract code, the sharded contract code can be called using this action.  This action is similar to the `FunctionCallAction` action.  It contains additional information about what type of sharded contract to call on the account.  Note that as seen in the FT example above, this action will also be used when a sharded contract code calls another one.
+- Inside a `ContractContext::Sharded` context, the only allowed actions are `UseGlobalContractAction`, `FunctionCallAction`, `SwitchContextAction`, and `SetContextPermissionsAction`.
+- Inside a `ContractContext::Sharded` context, `UseGlobalContractAction` is only valid if the global account identifier is exactly the same as the context target.
 
-```rust
-/// This is similar to the existing `FunctionCallAction`.  `FunctionCallAction`
-/// allows calling contract codes that are deployed using the
-/// `DeployContractAction` or the `UseGlobalContractAction` on an account.  This
-/// action allows calling contract codes that are deployed using the
-/// `SetShardedContractPermissionsAction`.
-struct ShardedFunctionCallAction {
-    // An account can be using multiple sharded contract codes.  This identifies
-    // which one should be called.
-    receiver_sharded_contract: CallShardedContractReceiver,
-    // additionally arguments are identical to `FunctionCallAction`.
-}
-```
 
 #### Storage namespace
 
-Today when a local or global contract code call accesses the storage, the following function is used to create the trie key used:
-
-Next, both `storage_write()` and `storage_read()` host functions use the `create_storage_key()` function to access storage.  To provide sufficient isolation for the state that subordinate accounts are creating, the following changes are proposed.
-
-New variants are added to the `TrieKey` to help store the contract data from the subordinate accounts and `create_storage_key` is updated to create the appropriate trie key.  These changes ensure that each subordinate account has its own storage namespace that cannot be accessed or corrupted by others.
+Entering a context changes how `storage_write()` and `storage_read()` construct a trie key.  A new trie key variant is added.
 
 ```rust
 enum TrieKey {
@@ -359,18 +353,18 @@ enum TrieKey {
     // new variant in TrieKey stores user values just like `TrieKey::ContractData`
     TrieKey::ShardedContractData { 
         account_id: AccountId,
-        sharded_contract_id: GlobalContractCodeIdentifier,,
+        sharded_contract_id: GlobalContractCodeIdentifier,
         key: Vec<u8>,
     }
 }
 
-fn create_storage_key(&self, key: &[u8], contract_type: ContractType) -> TrieKey {
-    match contract_type {
-        ContractType::MainContract => TrieKey::ContractData {
+fn create_storage_key(&self, key: &[u8], contract_context: ContractContext) -> TrieKey {
+    match contract_context {
+        ContractContext::Root => TrieKey::ContractData {
             account_id: self.account_id.clone(),
             key: key.to_vec(),
         },
-        ContractType::Sharded(sharded_contract_id) => {
+        ContractContext::Sharded(sharded_contract_id) => {
             TrieKey::ShardedContractData {
                 account_id: self.account_id.clone(),
                 sharded_contract_id,
@@ -401,47 +395,91 @@ impl GlobalContractCodeIdentifier {
 }
 ```
 
+
+#### Setting context permissions
+
+
+The `SetContextPermissionsAction` action can change what an installed sharded contract can do on a user's account.
+
+
+```rust
+struct SetContextPermissionsAction {
+    permissions: ContextPermissions,
+}
+
+#[non_exhaustive]
+enum ContextPermissions {
+    FullAccess,
+    Limited {
+        reserved_balance: Balance,
+    },
+    Blocked,
+}
+```
+
+Calling this action will insert or update the permission on the user's state trie for the specific sharded contract.
+
+```rust
+// new variant in TrieKey stores values of type `ContextPermissions`
+TrieKey::ContextPermissions { 
+    identifier: GlobalContractCodeIdentifier,
+}
+```
+
+The rules are:
+
+- A contract deployed with `FullAccess` permissions can do anything the main account can do.  This include all actions, without additional limits.
+- A contract deployed with `Limited` access cannot produce outgoing receipts with actions in the `ContractContext::Root` context (except for `SwitchContractAction` to enter a sharded context).
+    - Together with the rules defined on sharded contexts, this means a sharded contract can only produce two kinds of actions. One, function calls to other sharded functions. Two, start using a global contract in a sharded context with matching global account identifier.
+- A contract deployed with `Limited` access cannot attach deposits to a `FunctionCallAction`.
+- Calling `SwitchContext` with a context with `Blocked` permissions always fails.
+- Going in and out of `Blocked` permissions does not affect the existing contract state.
+
+
 #### Storage Limits
 
-- For limited sharded contracts, the user sets an explicit limit in `SetShardedContractPermissionsAction`.
-- Full access sharded contracts have no limits.  They are treated just like the main contract code.
-- Each sharded contract, limited or not, has its own ZBA limit that's added on top of the 770 bytes of the main account.
+The storage limit remains to be enforced on the account level, comparing the total bytes used of an account with the token balance at the end of each receipt.  Additional rules are introduced as follows.
+
+- Full access sharded contracts have no additional limits.  They are treated just like the main contract code.
+- For limited sharded contracts, the user sets an explicit limit in `SetContextPermissionsAction`.
+- Each sharded contract, limited or not, has its own ZBA limit, below which the storage usage is not counted towards the account storage usage.
+
+More details follow now.
+
 
 #### ZBA Limits for Sharded Contracts
 
-Each sharded contract, limited or not, has its own ZBA limit that's added on top of the 770 bytes of the main account.  The gas cost of `SetShardedContractPermissionsAction` is increased from its compute cost to pay for this limit in the same way the 770 bytes per account are paid for in the account creation.
+Each sharded contract, limited or not, has its own zero-balance limit that's added on top of the 770 bytes of the main account.  The gas cost of `UseGlobalContract` inside a sharded context is increased from its compute cost to pay for this limit in the same way the 770 bytes per account are paid for in the account creation.
 
-The limit per sharded contract is enough to store its permissions and a small number of contract state key-value pairs. Tentative proposal: 300 bytes per sharded contract.
+The limit per sharded contract must be enough to store its permissions and a small number of contract state key-value pairs. (e.g. `"balance" -> u128`)
 
-TODO: Exact math on limit
+Unlike the zero-balancelimit on accounts, even when a sharded contract goes over the ZBA limit, it will only need to maintain balance for the part over the zero-balance limit.  (For accounts, once a contract is no longer in the ZBA limit, it has to hold Near for all bytes. This made migration easier when introducing ZBAs. Migration is not an issue here.)
 
-Early estimate:
+*Discussion:*
+
+The exact size for the zero-balance limit has not been fully decided, yet.  A rough estimate says we need at least 217 bytes.
 
 - `TrieKey::ShardedContractData` requires 1 + 2 * (4 + 64) = 137 bytes  
-- `ShardedContractPermission` requires 1 + 16 = 17 bytes
+- `ContextPermissions` requires 1 + 16 = 17 bytes
 - Storing a `u128` on `balance` requires 16 bytes for the value, 7 bytes for the key, and 40 bytes for `storage_num_extra_bytes_record` = 63 bytes
 
-Hence, the required state of a sharded FT would be 217 bytes.
-
-Using the ft_transfer_call method on an account might require more state per outstanding transfer.  So the initial proposal is 300 bytes.
-
-Unlike the ZBA limit on accounts, even when a sharded contract goes over the ZBA limit, it will only need to maintain balance for the part over the ZBA limit.  (For accounts, once a contract is no longer in the ZBA limit, it has to hold Near for all bytes, since. This made migration easier when introducing ZBAs. Migration is not an issue here.)
+We could also use 770 bytes, like the existing zero-balance limit on accounts.  However, most of that was meant for access keys, which are not relevant here.
 
 
 #### Storage Limits for Full Access Sharded Contracts
 
-State usage of a full access sharded contract is added directly to the main accounts limits.
+The usage of the full access contract is not limited beyond the account storage limit.
 
-However, the ZBA limit per sharded contract (300 bytes) is free and not counted to the total limit.
+From the state usage of a full access sharded contract, the runtime subtracts the zero-balance limit.  If the result is positive, it is added to the account's storage usage.
+
 
 #### Storage Limits for Limited Sharded Contracts
 
-For limited sharded contracts, the user sets an explicit limit in `SetShardedContractPermissionsAction`.
+For limited sharded contracts, the user sets an explicit limit in `SetContextPermissionsAction`.
 
 ```rust
-SetShardedContractPermissionsAction {
-    sharded_contract_id: "alice.near".into(),
-    permissions: ShardedContractPermission::Limited {
+SetContextPermissionsAction {
+    permissions: ContextPermissions::Limited {
         reserved_balance: 1 * 10u128.pow(24),
     },
 }
@@ -466,6 +504,42 @@ pub struct AccountV2 {
 
 Going over the limit will abort the sharded function call.  Users can reduce the limit any time but they can not go lower than the actual usage.
 
+Just like with full access contracts, bytes below the zero-balance limit are not counted towards the usage limit.
+
+
+### Deleting an Account with Sharded Contracts
+
+Deleting a contract with sharded contracts is not allowed.
+
+This restriction can be lifted by future proposals, if the need for it arises.  The assumption is, however, that deleting accounts is rarely done today and remains like that for the foreseeable future.
+
+
+### Limit on contracts per account
+
+We allow at most 100 contracts per account, to avoid the state of a single account to grow larger than what a single shard can maintain.  (We assume all contracts under the same account will always stay on the same shard.)
+
+To track this, we add a field to the account structure in the state trie.
+
+```diff
+- pub struct AccountV2 {
++ pub struct AccountV3 {
+      /// The total not locked tokens.
+      amount: Balance,
+      /// The amount locked due to staking.
+      locked: Balance,
+      /// Storage used by the given account, includes account id, this struct, access keys and other data.
+      storage_usage: StorageUsage,
+      /// Type of contract deployed to this account, if any.
+      contract: AccountContract,
++     /// How many contracts the account has stored besides the root contract.
++     subcontracts_count: u32,
+  }
+```
+
+
+## Usage Guide
+
+Below are additional explanations on how sharded contracts can be built using the changes proposed in this NEP.
 
 
 ### Access Control
@@ -488,7 +562,7 @@ Sharded contracts can be used in two ways:
 - Full access: Outgoing function calls look just like they come from the main account, hence they can move assets held on other contracts.
 - Limited: No "normal" function calls are allowed, only sharded function calls are possible.
 
-Any receiver of sharded function calls must check the `predecessor_id` + `predecessor_sharded_contract_info` combination for authorization.  This only affects code deployed as sharded contracts.
+Any receiver of sharded function calls must check the `predecessor_id` + `predecessor_context` combination for authorization.  This only affects code deployed as sharded contracts.
 
 Already deployed code on chain today need no update if they do not use sharded contracts.
 
@@ -545,10 +619,6 @@ pub fn send_tokens(amount: Balance, receiver: AccountId, version: MethodVersion)
 
 ```
 
-### Deleting an Account with Sharded Contracts
-
-TODO: What happens when deleting an account with state in sharded contracts?
-
 
 ## Reference Implementation
 
@@ -562,11 +632,20 @@ TODO
 
 - Instead of explicit limited access / full-access permissions, we could say the sharded contract `ft.near` on `ft.near` implicitly has full access, while `ft.near` on any other account has only limited access.  This would mean anytime full access is required, we have to go through the central `ft.near@ft.near` account.
 - Instead of a ZBA limit per sharded contract, we could add a general way to burn tokens or gas for non-refundable storage on an account.  This would be its own NEP and limit what sharded contracts can do until that other NEP is also designed, approved and implemented.
+- Instead of `SwitchContext`, we could use `ShardedFunctionCall`.  This would be less flexible and require duplicating any action we want to allow targeting sharded contracts, e.g. `ShardedTransfer`, `ShardedDeployContract`, `ShardedAddAccessKey` and so on.
+- Instead of adding separate `caller` and `target` fields on `SwitchContext`, it could only have the `target` field. The caller info still needs to be sent with the receipt, though, for the callee to check who is calling. We could add the caller info as an extra field on every action receipt. This would increase the size of every action receipt by `sizeof(ContractContext)` and force us to add a new `ActionReceipt` version if we change `ContractContext` in the future. Putting it inside the action seems like the better choice.
+- Instead of limiting storage with permissions, we could give separate balance to each sharded contract and treat them as separate storage entities.  This can be awkward for users, who now have to maintain many balances per account.  This makes the wallet view presented to users more complex than desired.
 
 
 ## Future possibilities
 
-TODO
+The proposal has been written with the possibility of synchronous execution of function calls between contracts on the same account.
+
+- The current specification already allows to build a receipt that makes calls in multiple contexts by using more than one `SwitchContextAction` in a receipt.
+- If we add something like a synchronous promise API to the WASM runtime, this could dynamically add more actions to the currently executing receipt in the transaction runtime.  As long as the total attached gas is not exhausted, the transaction runtime could keep executing those dynamically added actions. (As opposed to putting them in a outgoing receipt, as it's done with the async promise API). This would allow to execute a function call within the same receipt, including callbacks.
+- If synchronous execution is enabled, we should also allow deploying multiple contracts per account without making them global.  We can add an enum variant to `ContractContext`, perhaps called `ContractContext::AccountExtension`.  When switching to a context of that type, `DeployContractAction` would be allowed to create a subcontract that's not deployed globally.  Since all outgoing receipts will have the caller set to a non-sharded context, it will not interfere with the access control of sharded contracts.  The user would remain in full control of the code, which could be re-deployed or even deleted.
+- Note that inside a `ContractContext::AccountExtension` context, we can still use `UseGlobalContractAction` to make use of cheap code sharing but without interfering with sharded contracts.  In this case, the context name can be chosen freely and does not need to be linked to the global code identifier.
+
 
 ## Consequences
 


### PR DESCRIPTION
Change the design to use two levels of access per sharded contract,
replacing the subordinate account design.

Also replace versioning support on the protocol with a hint that smart contract devs have to take care of it themselves.